### PR TITLE
fix(easyfft): remove dependency on generic_singleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ default = ["fallible"]
 
 [dependencies]
 array-init = "2.1.0"
-generic_singleton = "0.5.1"
 num-complex = { version = "0.4.5", features = ["serde"] }
 realfft = { version = "3.0.1"}
 rustfft = "6.0.1"

--- a/src/const_size.rs
+++ b/src/const_size.rs
@@ -75,7 +75,7 @@ impl<T: FftNum + Default, U: ?Sized + rustfft::Fft<T>, const SIZE: usize> Static
     for U
 {
     fn process_with_static_scratch(&self, buffer: &mut [Complex<T>; SIZE]) {
-        generic_singleton::get_or_init_thread_local!(
+        crate::get_or_init_thread_local!(
             || RefCell::new([Complex::default(); SIZE]),
             |scratch_buffer_ref| {
                 let mut scratch_buffer_ref = scratch_buffer_ref.borrow_mut();
@@ -141,12 +141,8 @@ mod tests {
     const ACCEPTABLE_ERROR: f64 = 0.000_000_000_000_01;
 
     fn fft_and_ifft_are_inverse_operations<const SIZE: usize>(array: [f64; SIZE]) {
-        let converted: Vec<_> = array
-            .fft()
-            .ifft()
-            .iter_mut()
-            .map(|sample| *sample / array.len() as f64)
-            .collect();
+        let converted: Vec<_> =
+            array.fft().ifft().iter_mut().map(|sample| *sample / array.len() as f64).collect();
         assert_eq!(array.len(), converted.len());
         for (converted, original) in converted.iter().zip(array.iter()) {
             approx::assert_ulps_eq!(converted.re, original, epsilon = ACCEPTABLE_ERROR);

--- a/src/const_size/realfft.rs
+++ b/src/const_size/realfft.rs
@@ -36,8 +36,8 @@
 use array_init::array_init;
 use realfft::num_traits::NumAssign;
 use realfft::num_traits::Zero;
-use rustfft::FftNum;
 use rustfft::num_complex::Complex;
+use rustfft::FftNum;
 use std::cell::RefCell;
 use std::ops::Add;
 use std::ops::AddAssign;
@@ -220,7 +220,7 @@ where
         with_real_fft_algorithm::<T>(SIZE, |r2c| {
             // TODO: Remove default dependency and unnesasary initialization
             // Pending issue: https://github.com/ejmahler/RustFFT/issues/105
-            generic_singleton::get_or_init_thread_local!(
+            crate::get_or_init_thread_local!(
                 || RefCell::new([Complex::default(); SIZE]),
                 |scratch_buffer_ref| {
                     let mut scratch_buffer_ref = scratch_buffer_ref.borrow_mut();
@@ -252,7 +252,7 @@ where
         // Pending issue: https://github.com/ejmahler/RustFFT/issues/105
         let mut output = [T::default(); SIZE];
         with_inverse_real_fft_algorithm::<T>(SIZE, |c2r| {
-            generic_singleton::get_or_init_thread_local!(
+            crate::get_or_init_thread_local!(
                 || RefCell::new([Complex::default(); SIZE]),
                 |scratch_buffer_ref| {
                     let mut scratch_buffer_ref = scratch_buffer_ref.borrow_mut();

--- a/src/dyn_size.rs
+++ b/src/dyn_size.rs
@@ -30,9 +30,9 @@ use std::collections::HashMap;
 
 #[rustfmt::skip]
 use ::realfft::num_traits::Zero;
+use rustfft::num_complex::Complex;
 use rustfft::Fft;
 use rustfft::FftNum;
-use rustfft::num_complex::Complex;
 
 pub mod realfft;
 
@@ -72,7 +72,7 @@ trait StaticScratchFft<T: FftNum>: Fft<T> {
 // Pending issue: https://github.com/ejmahler/RustFFT/issues/105
 impl<T: FftNum + Default, U: ?Sized + Fft<T>> StaticScratchFft<T> for U {
     fn process_with_static_scratch(&self, buffer: &mut [Complex<T>]) {
-        generic_singleton::get_or_init_thread_local!(
+        crate::get_or_init_thread_local!(
             || RefCell::new(HashMap::<usize, Box<[Complex<T>]>>::new()),
             |map| {
                 let len = self.get_inplace_scratch_len();

--- a/src/dyn_size/realfft.rs
+++ b/src/dyn_size/realfft.rs
@@ -22,12 +22,12 @@
 //!     assert_ulps_eq!(*manipulated, original * 10.0);
 //! }
 //! ```
-use realfft::ComplexToReal;
-use realfft::RealToComplex;
 use realfft::num_traits::NumAssign;
 use realfft::num_traits::Zero;
-use rustfft::FftNum;
+use realfft::ComplexToReal;
+use realfft::RealToComplex;
 use rustfft::num_complex::Complex;
+use rustfft::FftNum;
 
 #[cfg(feature = "serde")]
 use serde::Deserialize;
@@ -93,21 +93,19 @@ trait PrivateRealFftUsing<T> {
 impl<T: FftNum + Default, U: ?Sized + ComplexToReal<T>> StaticScratchComplexToReal<T> for U {
     unsafe fn process_with_static_scratch(&self, input: &[Complex<T>], output: &mut [T]) {
         debug_assert_eq!(input.len(), output.len() / 2 + 1);
-        generic_singleton::get_or_init_thread_local!(
+        crate::get_or_init_thread_local!(
             || RefCell::new(HashMap::<usize, Box<[Complex<T>]>>::new()),
             |input_clone_map| {
-                generic_singleton::get_or_init_thread_local!(
+                crate::get_or_init_thread_local!(
                     || RefCell::new(HashMap::<usize, Box<[Complex<T>]>>::new()),
                     |scratch_buffer_map| {
                         let scratch_buffer_len = self.get_scratch_len();
 
                         let mut scratch_buffer_map = scratch_buffer_map.borrow_mut();
                         let scratch =
-                            scratch_buffer_map
-                                .entry(scratch_buffer_len)
-                                .or_insert_with(|| {
-                                    vec![Complex::default(); scratch_buffer_len].into_boxed_slice()
-                                });
+                            scratch_buffer_map.entry(scratch_buffer_len).or_insert_with(|| {
+                                vec![Complex::default(); scratch_buffer_len].into_boxed_slice()
+                            });
                         let mut input_clone_map = input_clone_map.borrow_mut();
                         let input_clone = input_clone_map.entry(input.len()).or_insert_with(|| {
                             vec![Complex::default(); input.len()].into_boxed_slice()
@@ -137,21 +135,19 @@ impl<T: FftNum + Default, U: ?Sized + RealToComplex<T>> StaticScratchRealToCompl
     unsafe fn process_with_static_scratch(&self, input: &[T], output: &mut [Complex<T>]) {
         debug_assert_eq!(input.len() / 2 + 1, output.len());
 
-        generic_singleton::get_or_init_thread_local!(
+        crate::get_or_init_thread_local!(
             || RefCell::new(HashMap::<usize, Box<[T]>>::new()),
             |input_clone_map| {
-                generic_singleton::get_or_init_thread_local!(
+                crate::get_or_init_thread_local!(
                     || RefCell::new(HashMap::<usize, Box<[Complex<T>]>>::new()),
                     |scratch_buffer_map| {
                         let scratch_buffer_len = self.get_scratch_len();
                         let mut scratch_buffer_map = scratch_buffer_map.borrow_mut();
 
                         let scratch =
-                            scratch_buffer_map
-                                .entry(scratch_buffer_len)
-                                .or_insert_with(|| {
-                                    vec![Complex::default(); scratch_buffer_len].into_boxed_slice()
-                                });
+                            scratch_buffer_map.entry(scratch_buffer_len).or_insert_with(|| {
+                                vec![Complex::default(); scratch_buffer_len].into_boxed_slice()
+                            });
 
                         let mut input_clone_map = input_clone_map.borrow_mut();
                         let input_clone = input_clone_map
@@ -236,10 +232,7 @@ where
             assert_eq!(frequency_bins[frequency_bins.len() - 1].im, T::zero());
         }
         let inner = [&[Complex::new(zeroth_bin, T::zero())], frequency_bins].concat();
-        Self {
-            original_length,
-            inner: inner.into_boxed_slice(),
-        }
+        Self { original_length, inner: inner.into_boxed_slice() }
     }
 }
 
@@ -261,10 +254,7 @@ impl<T: Default + FftNum> Add for &DynRealDft<T> {
         for (i, r) in inner.iter_mut().zip(rhs.iter()) {
             *i = *i + r;
         }
-        DynRealDft {
-            original_length: self.original_length,
-            inner,
-        }
+        DynRealDft { original_length: self.original_length, inner }
     }
 }
 
@@ -288,10 +278,7 @@ impl<T: Default + FftNum> Mul for &DynRealDft<T> {
         for index in 0..self.len() {
             inner.push(self[index] * rhs[index]);
         }
-        DynRealDft {
-            inner: inner.into_boxed_slice(),
-            original_length: self.original_length,
-        }
+        DynRealDft { inner: inner.into_boxed_slice(), original_length: self.original_length }
     }
 }
 
@@ -313,10 +300,7 @@ impl<T: Default + FftNum> Mul<T> for &DynRealDft<T> {
         for index in 0..self.len() {
             inner.push(self[index] * rhs);
         }
-        DynRealDft {
-            inner: inner.into_boxed_slice(),
-            original_length: self.original_length,
-        }
+        DynRealDft { inner: inner.into_boxed_slice(), original_length: self.original_length }
     }
 }
 
@@ -338,10 +322,7 @@ impl<T: Default + FftNum> Mul<&[T]> for &DynRealDft<T> {
         for index in 0..self.len() {
             inner.push(self[index] * rhs[index]);
         }
-        DynRealDft {
-            inner: inner.into_boxed_slice(),
-            original_length: self.original_length,
-        }
+        DynRealDft { inner: inner.into_boxed_slice(), original_length: self.original_length }
     }
 }
 
@@ -391,10 +372,7 @@ impl<T: FftNum + Default> DynRealDft<T> {
     #[must_use]
     pub fn default(original_length: usize) -> Self {
         let inner = vec![Complex::default(); original_length / 2 + 1].into_boxed_slice();
-        Self {
-            original_length,
-            inner,
-        }
+        Self { original_length, inner }
     }
 }
 impl<T: FftNum + Zero> DynRealDft<T> {
@@ -426,10 +404,8 @@ impl<T: FftNum + Default> DynRealFft<T> for [T] {
         // TODO: Remove default dependency and unnesasary initialization
         // Pending issue: https://github.com/ejmahler/RustFFT/issues/105
         let output = vec![Complex::default(); self.len() / 2 + 1];
-        let mut output = DynRealDft {
-            inner: output.into_boxed_slice(),
-            original_length: self.len(),
-        };
+        let mut output =
+            DynRealDft { inner: output.into_boxed_slice(), original_length: self.len() };
         self.real_fft_using(&mut output);
         output
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,12 @@ use rustfft::FftPlanner;
 use std::cell::RefCell;
 use std::sync::Arc;
 
-pub use rustfft::FftNum;
 pub use rustfft::num_complex;
+pub use rustfft::FftNum;
 
 pub mod const_size;
 pub mod dyn_size;
+pub mod thread_local_map;
 /// This module re-exports all the traits under a single namespace to be easily consumed.
 ///
 /// I generally believe glob-imports are to be avoided. There are exceptions though and I believe
@@ -55,7 +56,7 @@ pub mod prelude {
 }
 
 fn with_fft_planner<T: FftNum>(with: impl FnMut(&RefCell<FftPlanner<T>>)) {
-    generic_singleton::get_or_init_thread_local!(|| RefCell::new(FftPlanner::new()), with);
+    crate::get_or_init_thread_local!(|| RefCell::new(FftPlanner::new()), with);
 }
 
 fn with_fft_algorithm<T: FftNum>(size: usize, mut with: impl FnMut(Arc<dyn rustfft::Fft<T>>)) {
@@ -84,7 +85,7 @@ fn with_real_fft_algorithm<T: FftNum>(
         let mut planner = planner.borrow_mut();
         with(planner.plan_fft_forward(size));
     };
-    generic_singleton::get_or_init_thread_local!(|| RefCell::new(RealFftPlanner::new()), with);
+    crate::get_or_init_thread_local!(|| RefCell::new(RealFftPlanner::new()), with);
 }
 
 fn with_inverse_real_fft_algorithm<T: FftNum>(
@@ -95,5 +96,5 @@ fn with_inverse_real_fft_algorithm<T: FftNum>(
         let mut planner = planner.borrow_mut();
         with(planner.plan_fft_inverse(size));
     };
-    generic_singleton::get_or_init_thread_local!(|| RefCell::new(RealFftPlanner::new()), with);
+    crate::get_or_init_thread_local!(|| RefCell::new(RealFftPlanner::new()), with);
 }

--- a/src/thread_local_map.rs
+++ b/src/thread_local_map.rs
@@ -1,0 +1,155 @@
+//! This module provides a thread-local map for storing and retrieving type-indexed data.
+//!
+//! It is useful for caching objects that are expensive to create, such as FFT planners,
+//! in a thread-safe manner without requiring global locks.
+
+use std::any::{Any, TypeId};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+/// Retrieves an item of type `T` from the provided map, or initializes it if it doesn't exist.
+///
+/// This function removes the item from the map before passing it to the `with` closure, and
+/// puts it back afterward. This allows re-entrant access to the map for *different* types
+/// without causing deadlocks or panics.
+pub fn get_or_init_with<T: 'static, R>(
+    map: &RefCell<HashMap<TypeId, Box<dyn Any>>>,
+    init: impl FnOnce() -> T,
+    with: impl FnOnce(&T) -> R,
+) -> R {
+    let type_id = TypeId::of::<T>();
+
+    // We remove the item from the map to avoid holding a Ref mut over the `with` call.
+    // This allows `with` to re-entrantly access the map for OTHER types.
+    let item: Box<dyn Any> = map.borrow_mut().remove(&type_id).unwrap_or_else(|| Box::new(init()));
+
+    // Downcast to the actual type
+    let item_ref = item.downcast_ref::<T>().unwrap();
+    let result = with(item_ref);
+
+    // Put it back
+    map.borrow_mut().insert(type_id, item);
+    result
+}
+
+/// A macro for getting or initializing an item in a thread-local map.
+///
+/// This macro initializes a thread-local map on first use and provides a safe interface
+/// to access it re-entrantly for different types.
+#[macro_export]
+macro_rules! get_or_init_thread_local {
+    ($init:expr, $with:expr) => {{
+        thread_local! {
+            static MAP: std::cell::RefCell<std::collections::HashMap<std::any::TypeId, Box<dyn std::any::Any>>> = std::cell::RefCell::new(std::collections::HashMap::new());
+        }
+        MAP.with(|map| $crate::thread_local_map::get_or_init_with(map, $init, $with))
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    fn with_cell<T: 'static, R>(init: i32, f: impl FnOnce(&Cell<i32>) -> R) -> R {
+        crate::get_or_init_thread_local!(|| Cell::new(init), f)
+    }
+
+    #[test]
+    fn test_basic_initialization() {
+        with_cell::<i32, _>(0, |cell| {
+            cell.set(cell.get() + 1);
+            assert_eq!(cell.get(), 1);
+        });
+
+        with_cell::<i32, _>(0, |cell| {
+            cell.set(cell.get() + 1);
+            assert_eq!(cell.get(), 2);
+        });
+    }
+
+    #[test]
+    fn test_different_types() {
+        with_cell::<i32, _>(0, |cell_i32| {
+            cell_i32.set(1);
+            with_cell::<f32, _>(0, |cell_f32| {
+                cell_f32.set(2);
+                assert_eq!(cell_f32.get(), 2);
+            });
+            assert_eq!(cell_i32.get(), 1);
+        });
+    }
+
+    #[test]
+    fn test_reentrancy_different_types_does_not_panic() {
+        with_cell::<i32, _>(10, |cell1| {
+            with_cell::<f32, _>(20, |cell2| {
+                assert_eq!(cell1.get(), 10);
+                assert_eq!(cell2.get(), 20);
+            });
+        });
+    }
+
+    #[test]
+    fn test_same_type_reentrancy_initializes_twice_and_overwrites() {
+        with_cell::<u32, _>(1, |outer_cell| {
+            outer_cell.set(2);
+            with_cell::<u32, _>(10, |inner_cell| {
+                // inner_cell sees the new initialization
+                assert_eq!(inner_cell.get(), 10);
+                inner_cell.set(20);
+            });
+            // Outer cell retains its state
+            assert_eq!(outer_cell.get(), 2);
+        });
+
+        // After outer completes, it overwrites the map with outer_cell's state,
+        // so the inner's value (20) is lost, reverting to 2.
+        with_cell::<u32, _>(100, |cell| {
+            assert_eq!(cell.get(), 2);
+        });
+    }
+
+    #[test]
+    fn test_thread_isolation() {
+        use std::thread;
+
+        with_cell::<i32, _>(10, |cell| {
+            cell.set(20);
+            assert_eq!(cell.get(), 20);
+
+            // Spawn a thread that should see its own separate value
+            let handle = thread::spawn(|| {
+                with_cell::<i32, _>(100, |inner_cell| {
+                    assert_eq!(inner_cell.get(), 100);
+                    inner_cell.set(200);
+                    assert_eq!(inner_cell.get(), 200);
+                });
+            });
+
+            handle.join().unwrap();
+
+            // Main thread's value should still be 20
+            assert_eq!(cell.get(), 20);
+        });
+    }
+
+    #[test]
+    fn test_panic_safety_reinitialization() {
+        use std::panic;
+
+        // Verify that if a `with` closure panics, the item is removed but re-initialized next time.
+        let result = panic::catch_unwind(|| {
+            with_cell::<i32, _>(5, |cell| {
+                cell.set(50);
+                panic!("Intentional panic inside with closure");
+            });
+        });
+
+        assert!(result.is_err());
+
+        // Next call should re-initialize with the default value (5) instead of failing or being poisoned.
+        with_cell::<i32, _>(5, |cell| {
+            assert_eq!(cell.get(), 5);
+        });
+    }
+}


### PR DESCRIPTION
The `easyfft` library previously relied on the external `generic_singleton` crate. This dependency has been identified as potentially unsound. To improve the reliability and safety of `easyfft`, the necessary functionality has been reimplemented locally within `easyfft`, and the dependency on the unsound crate has been removed.

This change preserves all existing `easyfft` functionality while eliminating the risks associated with the unsound dependency.